### PR TITLE
Fix ArgumentError

### DIFF
--- a/bin/qmc
+++ b/bin/qmc
@@ -4,7 +4,7 @@ require 'qiita-markdown'
 
 input = STDIN
 input = File.open(ARGV[0]) if ARGV.length > 0
-processor = Qiita::Markdown::Processor.new
+processor = Qiita::Markdown::Processor.new(hostname: "example.com")
 result = processor.call(input.read)
 output = result[:output].to_s
 STDOUT.write(output)


### PR DESCRIPTION
Hi @KOBA789,

I dockerized your `qiita-markdown-cli` gem as https://github.com/masutaka/docker-qiita-markdown-cli.

At that time, I encounterd the following problem.

```
$ qmc README.md
/usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline/filter.rb:160:in `needs': Missing context keys for Qiita::Markdown::Filters::ExternalLink: :hostname (ArgumentError)
        from /usr/local/bundle/gems/qiita-markdown-0.16.2/lib/qiita/markdown/filters/external_link.rb:23:in `validate'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline/filter.rb:42:in `initialize'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline/filter.rb:130:in `new'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline/filter.rb:130:in `call'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:124:in `block in perform_filter'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:162:in `instrument'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:123:in `perform_filter'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:109:in `block (2 levels) in call'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:108:in `each'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:108:in `inject'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:108:in `block in call'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:162:in `instrument'
        from /usr/local/bundle/gems/html-pipeline-2.5.0/lib/html/pipeline.rb:106:in `call'
        from /usr/local/bundle/gems/qiita-markdown-0.16.2/lib/qiita/markdown/base_processor.rb:32:in `call'
        from /usr/local/bundle/gems/qiita-markdown-cli-0.0.2/bin/qmc:8:in `<top (required)>'
        from /usr/local/bundle/bin/qmc:22:in `load'
        from /usr/local/bundle/bin/qmc:22:in `<main>'
```

This cause is for this commit https://github.com/increments/qiita-markdown/commit/f198614962224c6c712b8408aaafb2ec75910aa2.

If this Pull Request is merged, I can remove this workaround https://github.com/masutaka/docker-qiita-markdown-cli/blob/576d0d04e560ec665adbdb8ddbc29c0c47ca8a3e/Dockerfile#L10-L15.

Thanks.